### PR TITLE
Tidy desktop file

### DIFF
--- a/data/fbzx.desktop
+++ b/data/fbzx.desktop
@@ -1,13 +1,11 @@
 [Desktop Entry]
 X-MultipleArgs=false
 Type=Application
-Version=2.9.0
-Encoding=UTF-8
 Name=FBZX
 GenericName=A Sinclair ZX Spectrum emulator
-Comment=Play with the old, great games of the venerable ZX Spectrum
+Comment=Play the old, great games of the venerable ZX Spectrum
 TryExec=fbzx
 Exec=fbzx
 Keywords=emulator,sinclair,spectrum
-Categories=Game;
+Categories=Game
 Icon=fbzx


### PR DESCRIPTION
```
$ desktop-file-validate fbzx.desktop 
fbzx.desktop: error: value "2.9.0" for key "Version" in group "Desktop Entry" is not a known version
fbzx.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
```
Trailing semi-colons no longer required in Categories.