### PR TITLE
Categories must end with a semicolon.

### DIFF
--- a/data/fbzx.desktop
+++ b/data/fbzx.desktop
@@ -7,5 +7,5 @@ Comment=Play the old, great games of the venerable ZX Spectrum
 TryExec=fbzx
 Exec=fbzx
 Keywords=emulator,sinclair,spectrum
-Categories=Game
+Categories=Game;
 Icon=fbzx


### PR DESCRIPTION
Categories in desktop files must end with a semicolon.